### PR TITLE
Removed duplicate topsl.AppInit() call

### DIFF
--- a/govisor/ui.go
+++ b/govisor/ui.go
@@ -32,7 +32,6 @@ func doUI(client *rest.Client, url string, logger *log.Logger) error {
 		return e
 	}
 	app.Logf("Starting up user interface")
-	topsl.AppInit()
 	topsl.SetApplication(app)
 	app.ShowMain()
 	// periodic updates please


### PR DESCRIPTION
Duplicate topsl.AppInit() call causes invalid terminal state when application exists. This fixes https://github.com/gdamore/govisor/issues/37
